### PR TITLE
pulsar.cx: bump github actions runners to 2

### DIFF
--- a/hosts/pulsar.cx.sched-ext.com/default.nix
+++ b/hosts/pulsar.cx.sched-ext.com/default.nix
@@ -38,7 +38,7 @@
             tokenFile = config.age.secrets."github/sched_ext-nixos-self-hosted-runners".path;
             replace = true;
           };
-        }) 1);
+        }) 2);
 
     ## System packages
     environment = {


### PR DESCRIPTION

Very careful upgrade to 2 concurrent runners. We should be able to go far
higher here but taking it easy while we don't have a representative set of
jobs running on it.
