### PR TITLE
pulsar.cx: add git to github runners

### DIFF
--- a/hosts/pulsar.cx.sched-ext.com/default.nix
+++ b/hosts/pulsar.cx.sched-ext.com/default.nix
@@ -37,6 +37,10 @@
             url = "https://github.com/sched-ext";
             tokenFile = config.age.secrets."github/sched_ext-nixos-self-hosted-runners".path;
             replace = true;
+
+            extraPackages = with pkgs; [
+              git
+            ];
           };
         }) 2);
 


### PR DESCRIPTION

I'm trying to keep these environments clean, but not having `git` is really
annoying. You need to run the checkout action before opening a flake's Nix
develop, which requires an extra step. Adding git by default when every
reasonable action is going to need it seems like a good idea.
