### PR TITLE
pulsar.cx: bump github actions runners to 6

### DIFF
--- a/hosts/pulsar.cx.sched-ext.com/default.nix
+++ b/hosts/pulsar.cx.sched-ext.com/default.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
 let
-  numRunners = 4;
+  numRunners = 6;
 in
 {
   imports = [


### PR DESCRIPTION

We still have plenty of memory and disk space. Most of the work at the minute
ends up single threaded for a long time, so it's worth a bit of congestion on
the box to prevent queueing.
