### PR TITLE
pulsar.cx: correct workDir to private

### DIFF
--- a/hosts/pulsar.cx.sched-ext.com/default.nix
+++ b/hosts/pulsar.cx.sched-ext.com/default.nix
@@ -45,7 +45,7 @@ in
             tokenFile = config.age.secrets."github/sched_ext-nixos-self-hosted-runners".path;
             replace = true;
 
-            workDir = "%C/${cacheName}";
+            workDir = "%C/private/${cacheName}";
             serviceOverrides.CacheDirectory = cacheName;
 
             serviceOverrides.PrivateDevices = "false";


### PR DESCRIPTION

workDir was being set to `/var/cache/github-runner-pulsar-{0..5}` instead of
`/var/cache/private/github-runner-pulsar-{0..5}`. This is a symlink so it was
mostly working, but the GitHub Actions Cache step explicitly creates a path
relative to GITHUB_WORKSPACE and this was messing up the paths. This meant
caches failed to create on this machine, though they could load fine. Add in the
`/private` explicitly so these relative paths are accessible.

Test plan:
- Ran on https://github.com/sched-ext/scx/pull/1705 which failed before and
  passes now.
