### PR TITLE
pulsar.cx: add cachix cache

### DIFF
--- a/hosts/pulsar.cx.sched-ext.com/default.nix
+++ b/hosts/pulsar.cx.sched-ext.com/default.nix
@@ -52,8 +52,14 @@ in
             serviceOverrides.DeviceAllow = "/dev/kvm";
             serviceOverrides.SupplementaryGroups = [ "kvm" ];
 
+            # keep these limited as they're not pinned in the workflow, but this makes life much easier
             extraPackages = with pkgs; [
+              # required for actions/checkout
               git
+
+              # required for github caching
+              gnutar
+              zstd
             ];
           };
         })
@@ -107,6 +113,13 @@ in
       settings.experimental-features = [ "nix-command" "flakes" ];
       settings = {
         auto-optimise-store = true;
+
+        substituters = [
+          "https://sched-ext.cachix.org"
+        ];
+        trusted-public-keys = [
+          "sched-ext.cachix.org-1:dtoM9QOUUqJs3JkmSgVoKYp9cLY0BrupOqp4DVz35/g="
+        ];
       };
       gc = {
         automatic = true;


### PR DESCRIPTION

We don't have root on this machine in the GitHub Actions runners so can't load
untrusted caches into the store. We could risk not using the cache at all and
relying on the entry already being on this machine, but it would be better if
we can load them.

Add the cachix cache as a substituter and trust its key.

Test plan:
- Ran the cachix workflow. It works well.
