### PR TITLE
github-runners: add metal:nixos label

### DIFF
--- a/hosts/pulsar.cx.sched-ext.com/default.nix
+++ b/hosts/pulsar.cx.sched-ext.com/default.nix
@@ -45,6 +45,8 @@ in
             tokenFile = config.age.secrets."github/sched_ext-nixos-self-hosted-runners".path;
             replace = true;
 
+            extraLabels = [ "metal:nixos" ];
+
             workDir = "%C/private/${cacheName}";
             serviceOverrides.CacheDirectory = cacheName;
 


### PR DESCRIPTION
I want to experiment with different runner kinds, specifically running the runner in a rootless podman container to better emulate online GitHub Actions. Add a label "metal:nixos" to the existing runners so they can be differentiated in the CI config.