### PR TITLE
pulsar.cx: bump github actions runners to 10

### DIFF
--- a/hosts/pulsar.cx.sched-ext.com/default.nix
+++ b/hosts/pulsar.cx.sched-ext.com/default.nix
@@ -1,7 +1,7 @@
 { config, pkgs, lib, ... }:
 
 let
-  numRunners = 6;
+  numRunners = 10;
 in
 {
   imports = [


### PR DESCRIPTION
There's still plenty of disk space and memory on this host even when all of the runners are occupied. Bump the number of runners from 6->10 to better utilise the machine and get through queued jobs more quickly.